### PR TITLE
Invalidate modflow6 and flopy CI caches on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release CI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  invalidate-caches:
+    name: Invalidate GitHub actions caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invalidate Modflow6 cache
+        run: |
+          gh api --method DELETE -H "Accept: application/vnd.github+json" "/repos/MODFLOW-USGS/modflow6/actions/caches?key=modflow-exes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Invalidate FloPy cache
+        run: |
+          gh api --method DELETE -H "Accept: application/vnd.github+json" "/repos/modflowpy/flopy/actions/caches?key=modflow-exes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We currently cache Modflow executables in FloPy CI. The cache must be invalidated manually either via API or incrementing a counter in the key. It might be nicer to automate it. (Same could go for Modflow6).

Recently GitHub added the ability to [delete cache entries](https://docs.github.com/en/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key) via API with an exact key. This PR aims to use this to invalidate the exe caches when new versions are released. A few modifications are still needed to list cache contents and find/delete the proper entry. If the ability to [delete all entries matching a prefix](https://github.com/actions/cache/issues/2#issuecomment-1213414227) is added to the GitHub API, however, this should be sufficient as is (provided flopy and/or modflow6 CI cache executables with prefix `modflow-exes`).