### PR TITLE
ci: build linux dist on ubuntu-20.04 not ubuntu-22.04

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             os_script: ifortvars_linux.sh
             artifact_name: linux.zip
           - os: macos-latest


### PR DESCRIPTION
Binaries built with Intel Fortran on `ubuntu-22.04` runner images are backwards incompatible with 20.04, producing [`libc` errors](https://github.com/MODFLOW-USGS/modflow6/actions/runs/3638771730/jobs/6141398780#step:9:3224). Binaries built on 20.04 [are compatible](https://github.com/w-bonelli/modflow6/actions/runs/3642678135) at runtime with 22.04, though.