### PR TITLE
refactor: restore double precision executables

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,13 +56,18 @@ jobs:
 
           # move mf6 exes to the top-level bindir in the mf6 repo
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            ext=".exe"
-          ese
-            ext=""
+            eext=".exe"
+            oext=".dll"
+          elif [[ "$RUNNER_OS" == "Linux" ]]; then
+            eext=""
+            oext=".so"
+          else
+            eext=""
+            oext=".dylib"
           fi
-          cp "modflow6/bin/downloaded/mf6$ext" modflow6/bin
-          cp "modflow6/bin/downloaded/libmf6$ext" modflow6/bin
-          cp "modflow6/bin/downloaded/zbud6$ext" modflow6/bin
+          cp "modflow6/bin/downloaded/mf6$eext" modflow6/bin
+          cp "modflow6/bin/downloaded/libmf6$oext" modflow6/bin
+          cp "modflow6/bin/downloaded/zbud6$eext" modflow6/bin
 
           # set execute permissions
           if [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,39 +49,41 @@ jobs:
           compiler: intel-classic
           version: 2021.7
 
-      - name: Build modflow6
-        working-directory: modflow6
-        run: |
-          meson setup builddir --prefix=$(pwd) --libdir=bin -Ddebug=false
-          meson install -C builddir
-
-      - name: Show meson build log
-        if: failure()
-        working-directory: modflow6
-        run: cat builddir/meson-logs/meson-log.txt
-      
-      - name: Unit test modflow6
-        working-directory: modflow6
-        run: meson test --verbose --no-rebuild -C builddir
-
-      - name: Update FloPy
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-
-      - name: Get executables
-        working-directory: modflow6/autotest
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pytest -v -s get_exes.py
-
       - name: Build executables
-        working-directory: executables/scripts
-        run: python build_executables.py -p ../../modflow6/bin/downloaded
-        
-      - name: Set executable permission
-        if: runner.os != 'Windows'
-        working-directory: modflow6/bin/downloaded
-        run: sudo chmod +x *
+        run: |
+          # build all programs where mf6 autotests expect them
+          python executables/scripts/build_programs.py -p modflow6/bin/downloaded
+
+          # move mf6 exes to the top-level bindir in the mf6 repo
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ext=".exe"
+          ese
+            ext=""
+          fi
+          cp "modflow6/bin/downloaded/*mf6$ext" modflow6/bin
+          cp "modflow6/bin/downloaded/zbud6$ext" modflow6/bin
+          cp "modflow6/bin/downloaded/mf5to6$ext" modflow6/bin
+
+          # set execute permissions
+          if [[ "$RUNNER_OS" != "Windows" ]]; then
+            sudo chmod +x modflow6/bin/*
+            sudo chmod +x modflow6/bin/downloaded/*
+          fi
+      
+      - name: Upload executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: executables
+          path: ./*.zip
+
+      - name: Upload metadata
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: metadata
+          path: |
+            ./code.json
+            ./code.md
 
       - name: Test modflow6
         working-directory: modflow6/autotest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: MODFLOW 6 integration testing
+name: Integration testing
 on:
   push:
     paths-ignore:
@@ -48,6 +48,12 @@ jobs:
         with:
           compiler: intel-classic
           version: 2021.7
+      
+      - name: Build modflow6
+        working-directory: modflow6
+        run: |
+          meson setup builddir --prefix=$(pwd) --libdir=bin -Ddebug=false
+          meson install -C builddir
 
       - name: Build executables
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,4 +100,4 @@ jobs:
         working-directory: modflow6/autotest
         run: |
           python update_flopy.py
-          pytest -v -n auto --durations 0
+          pytest -v -n auto -k "not gwe" -m "not developmode" --durations 0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,7 @@ jobs:
           python executables/scripts/build_programs.py -p programs
 
           # move programs where mf6 autotests expect them
+          mkdir modflow6/bin/downloaded
           cp programs/* modflow6/bin/downloaded
 
           # move mf6 binaries to top-level bindir in mf6 repo
@@ -76,9 +77,9 @@ jobs:
             eext=""
             oext=".dylib"
           fi
-          cp "modflow6/bin/downloaded/mf6$eext" modflow6/bin
-          cp "modflow6/bin/downloaded/libmf6$oext" modflow6/bin
-          cp "modflow6/bin/downloaded/zbud6$eext" modflow6/bin
+          cp "programs/mf6$eext" modflow6/bin
+          cp "programs/libmf6$oext" modflow6/bin
+          cp "programs/zbud6$eext" modflow6/bin
 
           # set execute permissions
           if [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           meson setup builddir --prefix=$(pwd) --libdir=bin -Ddebug=false
           meson install -C builddir
-
+      
       - name: Build executables
         run: |
           # build all programs where mf6 autotests expect them
@@ -98,4 +98,6 @@ jobs:
 
       - name: Test modflow6
         working-directory: modflow6/autotest
-        run: pytest -v -n auto --durations 0
+        run: |
+          python update_flopy.py
+          pytest -v -n auto --durations 0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,6 +49,7 @@ jobs:
           compiler: intel-classic
           version: 2021.7
       
+      # only necessary because we need mf5to6 for mf6 autotests
       - name: Build modflow6
         working-directory: modflow6
         run: |
@@ -81,15 +82,15 @@ jobs:
             sudo chmod +x modflow6/bin/downloaded/*
           fi
       
-      - name: Upload executables
-        uses: actions/upload-artifact@v4
+      - name: Upload programs
+        uses: actions/upload-artifact@v3
         with:
-          name: executables
+          name: programs
           path: ./*.zip
 
       - name: Upload metadata
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: metadata
           path: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,12 +55,12 @@ jobs:
           meson setup builddir --prefix=$(pwd) --libdir=bin -Ddebug=false
           meson install -C builddir
       
-      - name: Build executables
+      - name: Build programs
         run: |
-          # build all programs where mf6 autotests expect them
+          # build programs where mf6 autotests expect them
           python executables/scripts/build_programs.py -p modflow6/bin/downloaded
 
-          # move mf6 exes to the top-level bindir in the mf6 repo
+          # move mf6 binaries to top-level bindir in mf6 repo
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             eext=".exe"
             oext=".dll"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,8 +58,12 @@ jobs:
       
       - name: Build programs
         run: |
-          # build programs where mf6 autotests expect them
-          python executables/scripts/build_programs.py -p modflow6/bin/downloaded
+          # build programs
+          mkdir programs
+          python executables/scripts/build_programs.py -p programs
+
+          # move programs where mf6 autotests expect them
+          cp programs/* modflow6/bin/downloaded
 
           # move mf6 binaries to top-level bindir in mf6 repo
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -86,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: programs
-          path: ./*.zip
+          path: programs.zip
 
       - name: Upload metadata
         if: runner.os == 'Linux'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: Integration testing
+name: MODFLOW 6 integration testing
 on:
   push:
     paths-ignore:
@@ -60,9 +60,9 @@ jobs:
           ese
             ext=""
           fi
-          cp "modflow6/bin/downloaded/*mf6$ext" modflow6/bin
+          cp "modflow6/bin/downloaded/mf6$ext" modflow6/bin
+          cp "modflow6/bin/downloaded/libmf6$ext" modflow6/bin
           cp "modflow6/bin/downloaded/zbud6$ext" modflow6/bin
-          cp "modflow6/bin/downloaded/mf5to6$ext" modflow6/bin
 
           # set execute permissions
           if [[ "$RUNNER_OS" != "Windows" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           pip list
 
       - name: Build executables
-        run: python scripts/build_executables.py
+        run: python scripts/build_programs.py
 
       - name: Upload distribution archive
         uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ target/
 # PyCharm
 .idea/
 
-# files in the examples directory
+# Local testing folders
 temp/
+bin/
 
+# Python virtual environments
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 wheel
-https://github.com/modflowpy/pymake/zipball/master
+https://github.com/modflowpy/pymake/zipball/develop
+https://github.com/MODFLOW-USGS/modflow-devtools/zipball/develop

--- a/scripts/build_executables.py
+++ b/scripts/build_executables.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     if keep:
         build_args.append("--keep")
     if not run_cmd(build_args):
-        raise RuntimeError("could not build single precision binaries")
+        raise RuntimeError("could not build default precision binaries")
 
     # build double precision binaries
     build_args = [

--- a/scripts/build_executables.py
+++ b/scripts/build_executables.py
@@ -79,11 +79,10 @@ if __name__ == "__main__":
     ]):
         raise RuntimeError(f"could not make code.json")
 
-    # build binaries
+    # build single precision binaries
     build_args = [
         "make-program", ":",
         "--appdir", path,
-        "--double",
         "-fc", "ifort",
         "-cc", cc,
         "--zip", f"{path}.zip",
@@ -91,4 +90,17 @@ if __name__ == "__main__":
     if keep:
         build_args.append("--keep")
     if not run_cmd(build_args):
-        raise RuntimeError("could not build binaries")
+        raise RuntimeError("could not build single precision binaries")
+
+    # build double precision binaries
+    build_args = [
+        "make-program", "mf2005,mflgr,mfnwt,mfusg",
+        "--appdir", path,
+        "--double",
+        "--keep",
+        "-fc", "ifort",
+        "-cc", cc,
+        "--zip", f"{path}.zip",
+    ]
+    if not run_cmd(build_args):
+        raise RuntimeError("could not build single precision binaries")

--- a/scripts/build_programs.py
+++ b/scripts/build_programs.py
@@ -103,4 +103,4 @@ if __name__ == "__main__":
         "--zip", f"{path}.zip",
     ]
     if not run_cmd(build_args):
-        raise RuntimeError("could not build single precision binaries")
+        raise RuntimeError("could not build double precision binaries")

--- a/scripts/build_programs.py
+++ b/scripts/build_programs.py
@@ -11,6 +11,7 @@ DBL_PREC_PROGRAMS = ["mf2005", "mflgr", "mfnwt", "mfusg"]
 
 
 def get_fc() -> str:
+    """Determine Intel Fortran compiler to use based on the current platform."""
     return "ifort"
 
 
@@ -71,6 +72,8 @@ if __name__ == "__main__":
     keep = bool(args.keep)
     path = Path(args.path)
     path.mkdir(parents=True, exist_ok=True)
+    zip_path = Path(path).with_suffix(".zip")
+    dp_programs = ",".join(DBL_PREC_PROGRAMS)
     retries = args.retries
     fc = get_fc()
     cc = get_cc()
@@ -83,7 +86,6 @@ if __name__ == "__main__":
             "--verbose",
         ]
     ), "could not make code.json"
-
     assert run_cmd(
         [
             "make-program",
@@ -99,8 +101,6 @@ if __name__ == "__main__":
         ]
         + (["--keep"] if keep else [])
     ), "could not build default precision binaries"
-
-    dp_programs = ",".join(DBL_PREC_PROGRAMS)
     assert run_cmd(
         [
             "make-program",
@@ -114,6 +114,7 @@ if __name__ == "__main__":
             "-cc",
             cc,
             "--zip",
-            f"{path}.zip",
+            str(zip_path),
         ]
     ), f"could not build double precision binaries: {dp_programs}"
+    assert zip_path.is_file(), "could not build distribution zipfile"


### PR DESCRIPTION
* use new `--double` arg for pymake `make-program` to make double precision versions of mf2005, mfusg, mflgr, and mfnwt
* add modflow-devtools to `requirements.txt`, use `ostags` module
* use develop branches of pymake and devtools in `requirements.txt`
* needs https://github.com/modflowpy/pymake/pull/158