### PR TITLE
refactor: accommodate recent pymake changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Upload programs
         uses: actions/upload-artifact@v3
         with:
-          name: programs-${{ runner.os }}
-          path: programs-${{ runner.os }}.zip
+          name: programs-${{ matrix.os }}
+          path: programs-${{ matrix.os }}.zip
 
       - name: Upload metadata
         if: runner.os == 'Linux'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,7 +71,7 @@ jobs:
 
           # move programs where mf6 autotests expect them
           mkdir modflow6/bin/downloaded
-          cp ostag/* modflow6/bin/downloaded
+          cp $ostag/* modflow6/bin/downloaded
 
           # move mf6 binaries to top-level bindir in mf6 repo
           if [[ "$RUNNER_OS" == "Windows" ]]; then

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,15 +56,22 @@ jobs:
           meson setup builddir --prefix=$(pwd) --libdir=bin -Ddebug=false
           meson install -C builddir
       
+      - name: Get OS tag
+        id: ostag
+        run: |
+          ostag=$(python -c "from modflow_devtools.ostags import get_ostag; print(get_ostag())")
+          echo "ostag=$ostag" >> $GITHUB_OUTPUT
+
       - name: Build programs
         run: |
           # build programs
-          mkdir programs
-          python executables/scripts/build_programs.py -p programs
+          ostag="${{ steps.ostag.outputs.ostag }}"
+          mkdir $ostag
+          python executables/scripts/build_programs.py -p $ostag
 
           # move programs where mf6 autotests expect them
           mkdir modflow6/bin/downloaded
-          cp programs/* modflow6/bin/downloaded
+          cp ostag/* modflow6/bin/downloaded
 
           # move mf6 binaries to top-level bindir in mf6 repo
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -77,9 +84,9 @@ jobs:
             eext=""
             oext=".dylib"
           fi
-          cp "programs/mf6$eext" modflow6/bin
-          cp "programs/libmf6$oext" modflow6/bin
-          cp "programs/zbud6$eext" modflow6/bin
+          cp "$ostag/mf6$eext" modflow6/bin
+          cp "$ostag/libmf6$oext" modflow6/bin
+          cp "$ostag/zbud6$eext" modflow6/bin
 
           # set execute permissions
           if [[ "$RUNNER_OS" != "Windows" ]]; then
@@ -90,8 +97,8 @@ jobs:
       - name: Upload programs
         uses: actions/upload-artifact@v3
         with:
-          name: programs-${{ matrix.os }}
-          path: programs-${{ matrix.os }}.zip
+          name: ${{ steps.ostag.outputs.ostag }}
+          path: ${{ steps.ostag.outputs.ostag }}.zip
 
       - name: Upload metadata
         if: runner.os == 'Linux'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,4 +106,5 @@ jobs:
         working-directory: modflow6/autotest
         run: |
           python update_flopy.py
-          pytest -v -n auto -k "not gwe" -m "not developmode" --durations 0
+          # when mf6.5.0 is released with new models and exes dist is updatd, remove filters below
+          pytest -v -n auto -k "not gwe and not swf and not prt" -m "not developmode" --durations 0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Upload programs
         uses: actions/upload-artifact@v3
         with:
-          name: programs
-          path: programs.zip
+          name: programs-${{ runner.os }}
+          path: programs-${{ runner.os }}.zip
 
       - name: Upload metadata
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           pip install -r requirements.txt
           pip list
 
-      - name: Build executables
+      - name: Build programs
         run: python scripts/build_programs.py
 
       - name: Upload distribution archive

--- a/scripts/build_programs.py
+++ b/scripts/build_programs.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from modflow_devtools.ostags import get_modflow_ostag
 
 DEFAULT_RETRIES = 3
-DBL_PREC_PROGRAMS = ["mf2005", "mflgr", "mfnwt", "mfusg"]
+DPRECISION_EXES = ["mf2005", "mflgr", "mfnwt", "mfusg"]
 
 
 def get_fc() -> str:
@@ -73,19 +73,11 @@ if __name__ == "__main__":
     path = Path(args.path)
     path.mkdir(parents=True, exist_ok=True)
     zip_path = Path(path).with_suffix(".zip")
-    dp_programs = ",".join(DBL_PREC_PROGRAMS)
+    dp_exes = ",".join(DPRECISION_EXES)
     retries = args.retries
     fc = get_fc()
     cc = get_cc()
 
-    assert run_cmd(
-        [
-            "make-code-json",
-            "-f",
-            str(path / "code.json"),
-            "--verbose",
-        ]
-    ), "could not make code.json"
     assert run_cmd(
         [
             "make-program",
@@ -104,7 +96,7 @@ if __name__ == "__main__":
     assert run_cmd(
         [
             "make-program",
-            dp_programs,
+            dp_exes,
             "--appdir",
             path,
             "--double",
@@ -116,5 +108,15 @@ if __name__ == "__main__":
             "--zip",
             str(zip_path),
         ]
-    ), f"could not build double precision binaries: {dp_programs}"
+    ), f"could not build double precision binaries: {dp_exes}"
+    assert run_cmd(
+        [
+            "make-code-json",
+            "-ad", str(path),
+            "-f",
+            str(path / "code.json"),
+            "--verbose",
+        ]
+    ), "could not make code.json"
     assert zip_path.is_file(), "could not build distribution zipfile"
+    print(f"created distribution zipfile: {zip_path}")

--- a/scripts/build_programs.py
+++ b/scripts/build_programs.py
@@ -1,6 +1,6 @@
 import argparse
-import sys
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -112,9 +112,8 @@ if __name__ == "__main__":
     assert run_cmd(
         [
             "make-code-json",
-            "-ad", str(path),
-            "-f",
-            str(path / "code.json"),
+            "-ad",
+            str(path),
             "--verbose",
         ]
     ), "could not make code.json"


### PR DESCRIPTION
* build `code.json/md` after building executables to include double precision entries in metadata
* use `--appdir` (`-ad`) option to specify appdir
* motivated by
  * https://github.com/modflowpy/pymake/pull/163
  * https://github.com/modflowpy/pymake/pull/164
* will fix flopy `get-modflow`, which relies on contents of `code.json` to unpack exes distribution