### PR TITLE
fix: include code.json in distribution zipfile

### DIFF
--- a/scripts/build_programs.py
+++ b/scripts/build_programs.py
@@ -115,6 +115,8 @@ if __name__ == "__main__":
             "-ad",
             str(path),
             "--verbose",
+            "--zip",
+            str(zip_path)
         ]
     ), "could not make code.json"
     assert zip_path.is_file(), "could not build distribution zipfile"


### PR DESCRIPTION
* `code.json` needs to be in the zipfile for flopy's `get-modflow` utility to parse it and extract a `--subset` of programs
* previously included by default &mdash; [now necessary to use new `--zip` option to pymake's `make-code-json`](https://github.com/modflowpy/pymake/commit/5f1064a7878ff0b41360fd99e0f7ef3969ee8279)
* fix [broken nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/7953667683/job/21710908917)