### PR TITLE
ci(release): multiple fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,9 @@ jobs:
           version=${{ env.GCC_V }}
           brew_prefix="$(brew --prefix)"
           libpath="$brew_prefix/opt/gcc@$version/lib/gcc/$version"
-          mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
-          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak 
+          # libgcc_s.1.1 has no static counterpart on Intel; only hide it on ARM
+          [[ "$(uname -m)" == "arm64" ]] && mv $libpath/libgcc_s.1.1.dylib $libpath/libgcc_s.1.1.dylib.bak
+          mv $libpath/libgfortran.5.dylib $libpath/libgfortran.5.dylib.bak
           mv $libpath/libquadmath.0.dylib $libpath/libquadmath.0.dylib.bak
           mv $libpath/libstdc++.6.dylib $libpath/libstdc++.6.dylib.bak
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,10 +193,9 @@ jobs:
         shell: python
         run: |
           import os
-          next_version = os.getenv('NEXT_VERSION') 
           line = "The programs, version numbers, and the date "
           line += "stamp on the downloaded file used to create the "
-          line += f"executables for version {next_version} are\n\n"
+          line += f"executables are\n\n"
           with open('Header.md', "w") as file:
               file.write(line)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
             ostag="${{ steps.ostag.outputs.ostag }}"
             fetched=$(pixi run --manifest-path modflow6/pixi.toml python scripts/fetch_releases.py --manifest releases.json --list)
             pixi run --manifest-path modflow6/pixi.toml make-program : --appdir $ostag --exclude "$fetched" --keep --zip $ostag.zip --verbose
-            pixi run --manifest-path modflow6/pixi.toml make-program mf2005,mfusg --appdir $ostag --double --keep --zip $ostag.zip --verbose
+            pixi run --manifest-path modflow6/pixi.toml make-program mf2005,mfusg,mfnwt,mflgr --appdir $ostag --double --keep --zip $ostag.zip --verbose
             pixi run --manifest-path modflow6/pixi.toml make-code-json --appdir $ostag --zip $ostag.zip --verbose
 
       - name: Show programs


### PR DESCRIPTION
* include double precision `mfnwtdbl`/`mflgrdbl`
* no next version substitution in release description
* only hide libgcc_s.1.1.dylib on arm mac