### PR TITLE
ci(release): bump py3.10 -> 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,13 +161,12 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install https://github.com/modflowpy/pymake/zipball/master
-          pip install https://github.com/MODFLOW-ORG/modflow-devtools/zipball/develop
 
       - name: Get last release tag
         id: last-tag


### PR DESCRIPTION
and just use devtools from the mf6 pixi env, no need for develop version